### PR TITLE
Stackplot plotting bug fix

### DIFF
--- a/src/pymsm/plotting.py
+++ b/src/pymsm/plotting.py
@@ -72,29 +72,33 @@ def competingrisks_stackplot(
     cifs_top = []
     for i, failure_type in enumerate(order_top):
         color = f"C{failure_type}"
-        cif = 1 - cumulative_densities[failure_type].values
+        cif = cumulative_densities[failure_type].values
+        
         if i == 0:
-            ax.fill_between(times, 1, cif, alpha=0.8, color=color)
+            inv_cif=1-cif
+            ax.fill_between(times, 1, inv_cif, alpha=0.8, color=color)
             ax.text(
                 x=times[-1] * 1.02,
-                y=(cif[-1] + (1 - cif[-1]) / 2),
+                y=(inv_cif[-1] + (1 - inv_cif[-1]) / 2),
                 s=state_labels[failure_type],
                 fontsize=fontsize,
                 color=color,
             )
         else:
-            cif = cif - cifs_top[i - 1]
-            ax.fill_between(times, cifs_top[i - 1], cif, alpha=0.8, color=color)
+            
+            cif = cif + cifs_top[i - 1]
+            inv_cif=1-cif
+            inv_top=1-cifs_top[i - 1]
+            ax.fill_between(times , inv_cif, inv_top , alpha=0.8, color=color)
             ax.text(
                 x=times[-1] * 1.02,
-                y=(cif[-1] + (cifs_top[i - 1][-1] - cif[-1]) / 2),
+                y=(inv_cif[-1] + (inv_top[-1] - inv_cif[-1]) / 2),
                 s=state_labels[failure_type],
                 fontsize=fontsize,
                 color=color,
             )
-        ax.plot(times, cif, color="k")
+        ax.plot(times, 1-cif, color="k")
         cifs_top.append(cif)
-
     cifs_bottom = []
     for i, failure_type in enumerate(order_bottom):
         color = f"C{failure_type}"

--- a/src/pymsm/utils.py
+++ b/src/pymsm/utils.py
@@ -12,7 +12,7 @@ def stepfunc(xs: np.ndarray, ys: np.ndarray) -> interp1d:
 
 
 def get_categorical_columns(df: pd.DataFrame, cat_cols: List) -> pd.DataFrame:
-    encoder = OneHotEncoder(drop="first", sparse=False)
+    encoder = OneHotEncoder(drop="first", sparse_output=False)
     new_df = pd.DataFrame(encoder.fit_transform(df[cat_cols]), dtype=int)
     new_df.columns = encoder.get_feature_names_out(cat_cols)
     return new_df


### PR DESCRIPTION
### Description
`competingrisks_stackplot` function does not work as intended when there are more than 1 plots to be stacked on top. 
### Steps to Reproduce
1- Create a test dataset with 4 states: 
Append the following rows to the [AIDSI dataset](https://hrossman.github.io/pymsm/full_examples/AIDSI_example)
```
new_status_data = {
    "patnr": [i+330 for i in range(10)],  # New patient numbers, continuing from 330
    "time": [6.5, 7.2, 8.1, 2.3, 1.5, 3.9, 4.8, 7.5, 8.3, 6.0],
    "status": [3, 3, 3, 3, 3, 3, 3, 3, 3, 3],  # New status value
    "cause": ["THIRD"]*10,
    "ccr5": ["WM", "WW", "WM", "WW", "WM", "WW", "WM", "WW", "WM", "WW"]
}
```
State diagram becomes the following:
![image](https://github.com/user-attachments/assets/146aa65e-f129-4819-8504-f7bb32c06ee1)

2-Plot the competing risks stackplot
```
competingrisks_stackplot(
    data=competing_risk_dataset,
    duration_col='time_transition_to_target',
    event_col ='target_state',
    order_top= [2,4],
    order_bottom = [3],
    state_labels = state_labels);

```

Expected output: 
![image](https://github.com/user-attachments/assets/86ef4dbe-cafa-4822-aa5c-c2a7deea7ff9)

Actual output:
![image](https://github.com/user-attachments/assets/577f8e56-4613-43d9-84c1-4aa48467630c)


### Problem

The issue occurs because the operation `cif = cif - cifs_top[i - 1]` incorrectly calculates the difference between the CIFs of competing risks events. In the case where `cif = 1 - x_2` and `cifs_top[-1] = 1 - x_1` , the result of the subtraction `cif - cifs_top[i - 1]` is `x_1 - x_2`. However, the intended operation should result in `1 - (x_1 + x_2)` to properly stack the areas on the top part of the plot.

### Changes
Updated the stacking logic for the cumulative incidence functions in the competingrisks_stackplot function.

Parameter `sparse` in OneHotEncoder was renamed to `sparse_output` starting from scikit-learn version 1.2. 





 
